### PR TITLE
feat(step-form): Add styles to responsive styles

### DIFF
--- a/src/assets/step-bg-mobile.svg
+++ b/src/assets/step-bg-mobile.svg
@@ -1,0 +1,14 @@
+<svg width="375" height="172" viewBox="0 0 375 172" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="375" height="172" fill="#483EFF"/>
+<mask id="mask0_0_474" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="0" y="0" width="375" height="172">
+<rect width="375" height="172" fill="white"/>
+</mask>
+<g mask="url(#mask0_0_474)">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-80.9251 219.812C-25.311 350.916 217.322 427.844 280.639 321.572C343.956 215.3 183.745 196.014 127.111 86.1962C70.4757 -23.6216 26.4674 -92.1632 -55.3652 -67.1445C-137.198 -42.1257 -136.539 88.7075 -80.9251 219.812Z" fill="#6259FF"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M311.62 304.909C400.568 263.458 447.71 94.5169 373.003 53.4688C298.295 12.4208 288.866 123.215 214.602 164.858C140.337 206.501 94.1937 238.455 113.391 294.208C132.588 349.961 222.671 346.361 311.62 304.909Z" fill="#F9818E"/>
+<path d="M212.247 111.33L227.795 95.4897" stroke="white" stroke-width="5" stroke-linecap="round" stroke-linejoin="bevel"/>
+<path d="M276.974 119.369L258.643 103.973" stroke="white" stroke-width="5" stroke-linecap="round" stroke-linejoin="bevel"/>
+<path d="M244.871 140.493L234.744 162.184" stroke="white" stroke-width="5" stroke-linecap="round" stroke-linejoin="bevel"/>
+<path d="M-29.624 225.367C24.6181 225.367 68.5901 181.395 68.5901 127.153C68.5901 72.9107 24.6181 28.9387 -29.624 28.9387C-83.8662 28.9387 -127.838 72.9107 -127.838 127.153C-127.838 181.395 -83.8662 225.367 -29.624 225.367Z" fill="#FFAF7E"/>
+</g>
+</svg>

--- a/src/components/ContentBox/ContentBox.tsx
+++ b/src/components/ContentBox/ContentBox.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Box, BoxProps } from '@mui/material';
+import { Box, BoxProps, SxProps, Theme } from '@mui/material';
 
 export interface ContentBoxProps extends BoxProps {
   children: React.ReactNode;
@@ -7,23 +7,33 @@ export interface ContentBoxProps extends BoxProps {
 
 export const ContentBox = ({ children, ...rest }: ContentBoxProps) => {
   return (
-    <Box
-      sx={{
-        backgroundColor: 'primary.contrastText',
-        borderRadius: '15px',
-        boxShadow: '0px 25px 40px -20px rgba(0, 0, 0, 0.0951141)',
-        margin: '0 auto',
-        maxWidth: '940px',
-        boxSizing: 'border-box',
-        padding: '16px',
-        display: 'flex',
-        flexDirection: 'row',
-      }}
-      {...rest}
-    >
+    <Box sx={contentBoxStyles} {...rest}>
       {children}
     </Box>
   );
 };
 
 export default ContentBox;
+
+const contentBoxStyles: SxProps<Theme> = [
+  ({
+    breakpoints: { down },
+    palette: {
+      primary: { contrastText },
+    },
+  }) => ({
+    backgroundColor: contrastText,
+    borderRadius: '15px',
+    boxShadow: '0px 25px 40px -20px rgba(0, 0, 0, 0.0951141)',
+    margin: '0 auto',
+    maxWidth: '940px',
+    boxSizing: 'border-box',
+    padding: '16px',
+    display: 'flex',
+    flexDirection: 'row',
+    [down('sm')]: {
+      flexDirection: 'column',
+      marginTop: '90px',
+    },
+  }),
+];

--- a/src/components/MainLayout/MainLayout.tsx
+++ b/src/components/MainLayout/MainLayout.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Box, Container } from '@mui/material';
+import { Box, Container, SxProps, Theme } from '@mui/material';
 import ContentBox from '../ContentBox/ContentBox';
 import StepsList from '../StepsList/StepsList';
 import { useFormContext } from '../../contexts/FormContext';
@@ -17,31 +17,13 @@ const steps = [
   <Steps5 key="5" />,
 ];
 
-const contentBoxStyles = {
-  display: 'flex',
-  flexDirection: 'column',
-  flex: 1,
-  paddingLeft: '98px',
-  paddingRight: `${98 - 16}px`,
-  paddingTop: '44px',
-  pb: 2,
-  justifyContent: 'space-between',
-  '& > form': {
-    display: 'flex',
-    flexDirection: 'column',
-    flex: 1,
-  },
-};
-
-const leftBoxStyles = { width: '274px' };
-
 export const MainLayout = () => {
   const {
     formState: { currentStep },
   } = useFormContext();
 
   return (
-    <Container>
+    <Container sx={{ mt: 8 }}>
       <ContentBox>
         <Box sx={leftBoxStyles}>
           <StepsList />
@@ -51,3 +33,28 @@ export const MainLayout = () => {
     </Container>
   );
 };
+
+const contentBoxStyles: SxProps<Theme> = [
+  {
+    display: 'flex',
+    flexDirection: 'column',
+    flex: 1,
+    paddingLeft: '98px',
+    paddingRight: `${98 - 16}px`,
+    paddingTop: '44px',
+    pb: 2,
+    justifyContent: 'space-between',
+    '& > form': {
+      display: 'flex',
+      flexDirection: 'column',
+      flex: 1,
+    },
+  },
+  ({ breakpoints: { down } }) => ({
+    [down('sm')]: {
+      padding: '32px 16px',
+    },
+  }),
+];
+
+const leftBoxStyles = { width: '274px' };

--- a/src/components/Steps1/Steps1.tsx
+++ b/src/components/Steps1/Steps1.tsx
@@ -7,6 +7,7 @@ import { Button } from '../Button/Button';
 import Header from '../Header/Header';
 import { TextField } from '../TextField/TextField';
 import { useFormContext } from '../../contexts/FormContext';
+import { footerStyles } from '../../styles/footer';
 
 const boxStyles = {
   display: 'flex',
@@ -73,7 +74,7 @@ export const Steps1 = () => {
           />
         </Box>
       </Box>
-      <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
+      <Box sx={footerStyles}>
         <MUIButton
           onClick={handlePrevStep}
           sx={{

--- a/src/components/Steps2/Steps2.tsx
+++ b/src/components/Steps2/Steps2.tsx
@@ -4,6 +4,7 @@ import { Button as MUIButton, Box } from '@mui/material';
 import { Button } from '../Button/Button';
 import Header from '../Header/Header';
 import { useFormContext } from '../../contexts/FormContext';
+import { footerStyles } from '../../styles/footer';
 
 const boxStyles = {
   display: 'flex',
@@ -41,7 +42,7 @@ export const Steps2 = () => {
       <Box sx={boxStyles}>
         <Box sx={{ ...boxStyles, pt: 4 }}>Step 2</Box>
       </Box>
-      <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
+      <Box sx={footerStyles}>
         <MUIButton
           onClick={handlePrevStep}
           sx={{

--- a/src/components/Steps3/Steps3.tsx
+++ b/src/components/Steps3/Steps3.tsx
@@ -4,6 +4,7 @@ import { Button as MUIButton, Box } from '@mui/material';
 import { Button } from '../Button/Button';
 import Header from '../Header/Header';
 import { useFormContext } from '../../contexts/FormContext';
+import { footerStyles } from '../../styles/footer';
 
 const boxStyles = {
   display: 'flex',
@@ -42,7 +43,7 @@ export const Steps3 = () => {
       <Box sx={boxStyles}>
         <Box sx={{ ...boxStyles, pt: 4 }}>Step 3</Box>
       </Box>
-      <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
+      <Box sx={footerStyles}>
         <MUIButton
           onClick={handlePrevStep}
           sx={{

--- a/src/components/Steps4/Steps4.tsx
+++ b/src/components/Steps4/Steps4.tsx
@@ -4,6 +4,7 @@ import { Button as MUIButton, Box } from '@mui/material';
 import { Button } from '../Button/Button';
 import Header from '../Header/Header';
 import { useFormContext } from '../../contexts/FormContext';
+import { footerStyles } from '../../styles/footer';
 
 const boxStyles = {
   display: 'flex',
@@ -42,7 +43,7 @@ export const Steps4 = () => {
       <Box sx={boxStyles}>
         <Box sx={{ ...boxStyles, pt: 4 }}>Step 4</Box>
       </Box>
-      <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
+      <Box sx={footerStyles}>
         <MUIButton
           onClick={handlePrevStep}
           sx={{

--- a/src/components/StepsList/StepsList.tsx
+++ b/src/components/StepsList/StepsList.tsx
@@ -1,19 +1,10 @@
 import React from 'react';
-import { styled } from '@mui/material/styles';
+import { SxProps, Theme } from '@mui/material/styles';
 import { Grid } from '@mui/material';
 import StepsListItem from './StepsListItem';
 import stepBg from '../../assets/step-bg.svg';
+import stepBgMobile from '../../assets/step-bg-mobile.svg';
 import { useFormContext } from '../../contexts/FormContext';
-
-const StyledGrid = styled(Grid)(({ theme: { palette } }) => ({
-  backgroundColor: palette.secondary.main,
-  backgroundImage: `url(${stepBg})`,
-  backgroundRepeat: 'no-repeat',
-  backgroundPosition: 'center',
-  maxWidth: '274px',
-  minHeight: '568px',
-  borderRadius: '10px',
-}));
 
 const steps = [
   {
@@ -42,15 +33,7 @@ export const StepsList = () => {
   const { formState } = useFormContext();
 
   return (
-    <StyledGrid
-      container
-      sx={{
-        px: 3,
-        paddingTop: '28px',
-        flexWrap: 'nowrap',
-        flexDirection: 'column',
-      }}
-    >
+    <Grid container sx={contentStyles}>
       {steps.map(({ title, subtitle, step }, index) => (
         <StepsListItem
           key={step}
@@ -60,8 +43,43 @@ export const StepsList = () => {
           activeItem={formState.currentStep === index}
         />
       ))}
-    </StyledGrid>
+    </Grid>
   );
 };
 
 export default StepsList;
+
+const contentStyles: SxProps<Theme> = [
+  ({
+    palette: {
+      secondary: { main: backgroundColor },
+    },
+    breakpoints: { down },
+  }) => ({
+    px: 3,
+    paddingTop: '28px',
+    flexWrap: 'nowrap',
+    flexDirection: 'column',
+    backgroundColor,
+    backgroundImage: `url(${stepBg})`,
+    backgroundRepeat: 'no-repeat',
+    backgroundPosition: 'center',
+    maxWidth: '274px',
+    minHeight: '568px',
+    borderRadius: '10px',
+    [down('sm')]: {
+      position: 'absolute',
+      zIndex: -10,
+      top: 0,
+      maxWidth: '100%',
+      left: 0,
+      borderRadius: '0px',
+      flexDirection: 'row',
+      minHeight: '172px',
+      padding: '18px 15%',
+      backgroundImage: `url(${stepBgMobile})`,
+      backgroundRepeat: 'no-repeat',
+      backgroundSize: 'cover',
+    },
+  }),
+];

--- a/src/components/StepsList/StepsListItem.tsx
+++ b/src/components/StepsList/StepsListItem.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Grid } from '@mui/material';
+import { Grid, SxProps, Theme } from '@mui/material';
 import {
   StyledRoundBox,
   StyledNumber,
@@ -22,13 +22,13 @@ export const StepsListItem = ({
 }: StepsListItemProps) => {
   return (
     <Grid item xs={12}>
-      <Grid container wrap="nowrap" sx={{ mx: 'auto', padding: '13px' }}>
+      <Grid container wrap="nowrap" sx={contentListStyles}>
         <Grid item>
           <StyledRoundBox state={activeItem?.toString()}>
             <StyledNumber state={activeItem?.toString()}>{step}</StyledNumber>
           </StyledRoundBox>
         </Grid>
-        <Grid item sx={{ pl: 2 }}>
+        <Grid item sx={contentItemStyles}>
           <StyledTitle sx={{ pb: 1 }}>{title}</StyledTitle>
           <StyledSubTitle>{subtitle}</StyledSubTitle>
         </Grid>
@@ -38,3 +38,23 @@ export const StepsListItem = ({
 };
 
 export default StepsListItem;
+
+const contentListStyles: SxProps<Theme> = [
+  {
+    mx: 'auto',
+    padding: '13px',
+  },
+  ({ breakpoints: { down } }) => ({
+    [down('sm')]: {
+      justifyContent: 'center',
+    },
+  }),
+];
+const contentItemStyles: SxProps<Theme> = [
+  ({ breakpoints: { down } }) => ({
+    pl: 2,
+    [down('sm')]: {
+      display: 'none',
+    },
+  }),
+];

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -8,30 +8,6 @@ import {
   Typography,
 } from '@mui/material';
 
-const inputPropsStyles = {
-  padding: '13px 14px',
-  fontSize: '16px',
-  lineHeight: '18px',
-};
-
-const inputStyles = (error?: string): SxProps<Theme> => [
-  { '& .MuiOutlinedInput-notchedOutline': { opacity: 0 }, borderRadius: '8px' },
-  ({ palette: { secondary, info, error: errorStyle } }) => ({
-    '&:hover, &:active': { border: `1px solid ${secondary.main}` },
-    border: `1px solid ${error ? errorStyle.main : info.dark} `,
-  }),
-];
-
-const errorLabelStyles: SxProps<Theme> = [
-  ({ palette: { error } }) => ({
-    display: 'block',
-    mb: 1,
-    fontWeight: 700,
-    justifyContent: 'space-between',
-    color: error.main,
-  }),
-];
-
 export interface TextFieldProps extends OutlinedInputProps {
   label?: string;
   value?: string;
@@ -82,3 +58,27 @@ export const TextField = forwardRef(
 TextField.displayName = 'TextField';
 
 export default TextField;
+
+const inputPropsStyles = {
+  padding: '13px 14px',
+  fontSize: '16px',
+  lineHeight: '18px',
+};
+
+const inputStyles = (error?: string): SxProps<Theme> => [
+  { '& .MuiOutlinedInput-notchedOutline': { opacity: 0 }, borderRadius: '8px' },
+  ({ palette: { secondary, info, error: errorStyle } }) => ({
+    '&:hover, &:active': { border: `1px solid ${secondary.main}` },
+    border: `1px solid ${error ? errorStyle.main : info.dark} `,
+  }),
+];
+
+const errorLabelStyles: SxProps<Theme> = [
+  ({ palette: { error } }) => ({
+    display: 'block',
+    mb: 1,
+    fontWeight: 700,
+    justifyContent: 'space-between',
+    color: error.main,
+  }),
+];

--- a/src/styles/footer.ts
+++ b/src/styles/footer.ts
@@ -1,0 +1,21 @@
+import { SxProps, Theme } from '@mui/material';
+
+export const footerStyles: SxProps<Theme> = [
+  ({
+    breakpoints: { down },
+    palette: {
+      primary: { contrastText: background },
+    },
+  }) => ({
+    display: 'flex',
+    justifyContent: 'space-between',
+    [down('sm')]: {
+      position: 'absolute',
+      bottom: 0,
+      background,
+      right: 0,
+      left: 0,
+      padding: '16px',
+    },
+  }),
+];

--- a/src/theme.tsx
+++ b/src/theme.tsx
@@ -2,6 +2,15 @@ import { createTheme } from '@mui/material/styles';
 
 // A custom theme for this app
 const theme = createTheme({
+  breakpoints: {
+    values: {
+      xs: 0,
+      sm: 780,
+      md: 900,
+      lg: 1200,
+      xl: 1536,
+    },
+  },
   typography: {
     fontFamily: ['Ubuntu', '-apple-system', 'Arial'].join(','),
     fontSize: 16,


### PR DESCRIPTION
## 📝 Description

Add styles to responsive styles

## 🖼️ Screenshots

![Kapture 2023-04-21 at 17 38 47](https://user-images.githubusercontent.com/1288502/233853726-5d91ec1f-3086-45ec-873f-d5bb416ca2c2.gif)


## 📁 Files Changed

	new file:   src/assets/step-bg-mobile.svg
	new file:   src/styles/footer.ts
	modified:   src/components/ContentBox/ContentBox.tsx
	modified:   src/components/MainLayout/MainLayout.tsx
	modified:   src/components/Steps1/Steps1.tsx
	modified:   src/components/Steps2/Steps2.tsx
	modified:   src/components/Steps3/Steps3.tsx
	modified:   src/components/Steps4/Steps4.tsx
	modified:   src/components/StepsList/StepsList.tsx
	modified:   src/components/StepsList/StepsListItem.tsx
	modified:   src/components/TextField/TextField.tsx
	modified:   src/theme.tsx

## 🏃‍♀️ Commands Needed to Run Changes

N/A

## 🧪 Unit Tests

Does this PR include unit tests? [No]
